### PR TITLE
Fix client initialization

### DIFF
--- a/client/src/App.js
+++ b/client/src/App.js
@@ -10,14 +10,15 @@ class App extends Component {
     super();
 
     this.state = {
-      title: '',
       blobs: [],
       mainPlayerId: 0
     }
   }
 
   componentDidMount() {
-    this.subscriptions = [];
+    this.subscriptions = [
+      GameState.get('initialize').subscribe(this.initialize)
+    ];
   }
 
   componentWillUnmount() {
@@ -71,7 +72,6 @@ class App extends Component {
 
     return (
       <div>
-        <h1>{this.state.title}</h1>
         <MainPlayer/>
         {blobComponents}
       </div>

--- a/client/src/App.js
+++ b/client/src/App.js
@@ -27,7 +27,6 @@ class App extends Component {
 
   initialize = data => {
     this.setState(prevState => ({
-      title: data.title,
       blobs: data.blobs.filter(blob => blob.id !== data.id),
       mainPlayerId: data.id
     }));

--- a/src/server.js
+++ b/src/server.js
@@ -47,7 +47,6 @@ function init(log) {
       id: player.id,
       location: player.location,
       size: player.size,
-      title: 'Blobber 2',
       blobs: blobs
     });
 


### PR DESCRIPTION
Previous merge removed the subscription that initializes the client. This made the client not respond to updates about new players and their movement.

This PR finishes removing the title from the page, but keeps the client aware of other players' state.